### PR TITLE
Redesign: custom layout with Instrument Serif, Google Sans Code, dark…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: My Site
+title: JY notes
 description: A personal homepage built with Jekyll and GitHub Pages.
 url: "" # e.g. https://jyslash.github.io
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="system">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title and page.title != "Home" %}{{ page.title }} — {% endif %}JY notes</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Code:ital,wght@0,300..800;1,300..800&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  <div class="app-shell">
+
+    <nav class="nav-rail">
+      <div class="nav-header">
+        <a href="{{ '/' | relative_url }}" class="site-title" data-url="{{ '/' | relative_url }}">JY notes</a>
+        <div class="theme-toggle" role="group" aria-label="Color theme">
+          <button class="theme-btn" data-theme="light" title="Light mode">Light</button>
+          <button class="theme-btn" data-theme="system" title="System default">System</button>
+          <button class="theme-btn" data-theme="dark" title="Dark mode">Dark</button>
+        </div>
+      </div>
+
+      <ul class="post-list">
+        {% for post in site.posts %}
+        <li class="post-entry{% if page.url == post.url %} active{% endif %}">
+          <a href="{{ post.url | relative_url }}" class="post-link" data-url="{{ post.url | relative_url }}">
+            <span class="post-meta-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+            <span class="post-nav-title">{{ post.title }}</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </nav>
+
+    <main class="content-area" id="content-area">
+      {{ content }}
+    </main>
+
+  </div>
+  <script src="{{ '/assets/js/app.js' | relative_url }}"></script>
+</body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+<div class="home-welcome">
+  <h1 class="home-title">JY notes</h1>
+  <p class="home-subtitle">Select a post from the left to start reading.</p>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+<article class="post">
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}">
+      {{ page.date | date: "%B %-d, %Y" }}
+    </time>
+  </header>
+  <div class="post-body">
+    {{ content }}
+  </div>
+</article>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,437 @@
+---
+---
+
+/* ============================================================
+   CSS Custom Properties — Light (default)
+   ============================================================ */
+:root {
+  --font-serif:  "Instrument Serif", Georgia, "Times New Roman", serif;
+  --font-body:   "Google Sans Code", "SF Mono", ui-monospace, monospace;
+
+  --bg:          #f7f5f0;
+  --bg-nav:      #efede7;
+  --bg-hover:    #e5e2d9;
+  --bg-active:   #dedad0;
+  --text:        #1a1a18;
+  --text-muted:  #6b6b63;
+  --text-nav:    #2a2a26;
+  --border:      #d8d5cc;
+  --accent:      #3b5bdb;
+  --accent-soft: rgba(59, 91, 219, 0.12);
+}
+
+/* Dark theme */
+html[data-theme="dark"] {
+  --bg:          #141413;
+  --bg-nav:      #1c1c1a;
+  --bg-hover:    #252522;
+  --bg-active:   #2e2e2a;
+  --text:        #e6e3db;
+  --text-muted:  #888880;
+  --text-nav:    #cac7be;
+  --border:      #2e2e2a;
+  --accent:      #748ffc;
+  --accent-soft: rgba(116, 143, 252, 0.15);
+}
+
+/* System theme — follow OS preference */
+@media (prefers-color-scheme: dark) {
+  html[data-theme="system"] {
+    --bg:          #141413;
+    --bg-nav:      #1c1c1a;
+    --bg-hover:    #252522;
+    --bg-active:   #2e2e2a;
+    --text:        #e6e3db;
+    --text-muted:  #888880;
+    --text-nav:    #cac7be;
+    --border:      #2e2e2a;
+    --accent:      #748ffc;
+    --accent-soft: rgba(116, 143, 252, 0.15);
+  }
+}
+
+/* ============================================================
+   Reset
+   ============================================================ */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: 15px;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ============================================================
+   App Shell — two-column layout
+   ============================================================ */
+.app-shell {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ============================================================
+   Nav Rail — left 25%
+   ============================================================ */
+.nav-rail {
+  width: 25%;
+  min-width: 200px;
+  max-width: 300px;
+  background: var(--bg-nav);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.nav-header {
+  padding: 1.5rem 1.25rem 1.125rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.site-title {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-style: italic;
+  color: var(--text-nav);
+  text-decoration: none;
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+
+.site-title:hover {
+  color: var(--accent);
+}
+
+/* Theme toggle */
+.theme-toggle {
+  display: flex;
+  gap: 3px;
+}
+
+.theme-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 9px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  line-height: 1.5;
+}
+
+.theme-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.theme-btn.active {
+  background: var(--bg-active);
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+/* Post list */
+.post-list {
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
+  padding: 0.5rem 0;
+}
+
+.post-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.post-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.post-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.post-link {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0.625rem 1.25rem;
+  text-decoration: none;
+  color: var(--text-nav);
+  border-left: 2px solid transparent;
+  transition: background 0.1s;
+}
+
+.post-link:hover {
+  background: var(--bg-hover);
+}
+
+.post-entry.active .post-link {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+.post-meta-date {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  line-height: 1;
+}
+
+.post-nav-title {
+  font-size: 0.825rem;
+  line-height: 1.35;
+}
+
+/* ============================================================
+   Content Area — right 75%
+   ============================================================ */
+.content-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 3.5rem 4rem;
+  scroll-padding-top: 1rem;
+}
+
+.content-area::-webkit-scrollbar {
+  width: 6px;
+}
+
+.content-area::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.content-area::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+/* ============================================================
+   Home welcome screen
+   ============================================================ */
+.home-welcome {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 55vh;
+  max-width: 540px;
+}
+
+.home-title {
+  font-family: var(--font-serif);
+  font-size: 3.25rem;
+  font-style: italic;
+  color: var(--text);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.625rem;
+}
+
+.home-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* ============================================================
+   Post
+   ============================================================ */
+.post {
+  max-width: 660px;
+}
+
+.post-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.post-title {
+  font-family: var(--font-serif);
+  font-size: 2.375rem;
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+}
+
+.post-date {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+/* Post body */
+.post-body {
+  font-size: 0.9625rem;
+  line-height: 1.8;
+  color: var(--text);
+}
+
+.post-body h1,
+.post-body h2,
+.post-body h3,
+.post-body h4,
+.post-body h5,
+.post-body h6 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  color: var(--text);
+  margin-top: 2.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.post-body h1 { font-size: 1.875rem; }
+.post-body h2 { font-size: 1.5rem; }
+.post-body h3 { font-size: 1.25rem; }
+
+.post-body p {
+  margin-bottom: 1.25rem;
+}
+
+.post-body a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.post-body a:hover {
+  text-decoration: none;
+}
+
+.post-body code {
+  font-family: var(--font-body);
+  font-size: 0.875em;
+  background: var(--bg-nav);
+  border: 1px solid var(--border);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+.post-body pre {
+  background: var(--bg-nav);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 1.125rem 1.25rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+  line-height: 1.65;
+}
+
+.post-body pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+.post-body blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 1.125rem;
+  color: var(--text-muted);
+  margin: 1.5rem 0;
+  font-style: italic;
+}
+
+.post-body ul,
+.post-body ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.post-body li {
+  margin-bottom: 0.3rem;
+}
+
+.post-body img {
+  max-width: 100%;
+  border-radius: 6px;
+  margin: 1.5rem 0;
+}
+
+.post-body hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+/* ============================================================
+   Loading state
+   ============================================================ */
+.content-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding-top: 2rem;
+}
+
+.content-loading::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ============================================================
+   Responsive — below 640px collapse to stacked
+   ============================================================ */
+@media (max-width: 640px) {
+  body {
+    overflow: auto;
+  }
+
+  .app-shell {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .nav-rail {
+    width: 100%;
+    max-width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .post-list {
+    max-height: 180px;
+  }
+
+  .content-area {
+    padding: 2rem 1.5rem;
+    overflow-y: visible;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,112 @@
+/* ============================================================
+   Theme toggle
+   ============================================================ */
+const THEME_KEY = 'jy-theme';
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem(THEME_KEY, theme);
+  document.querySelectorAll('.theme-btn').forEach(function (btn) {
+    btn.classList.toggle('active', btn.dataset.theme === theme);
+  });
+}
+
+function initTheme() {
+  var saved = localStorage.getItem(THEME_KEY) || 'system';
+  applyTheme(saved);
+}
+
+document.querySelectorAll('.theme-btn').forEach(function (btn) {
+  btn.addEventListener('click', function () {
+    applyTheme(btn.dataset.theme);
+  });
+});
+
+initTheme();
+
+/* ============================================================
+   SPA navigation — keep nav persistent, load post content
+   ============================================================ */
+var contentArea = document.getElementById('content-area');
+
+function setActiveLink(url) {
+  document.querySelectorAll('.post-entry').forEach(function (entry) {
+    var link = entry.querySelector('.post-link');
+    if (link) {
+      entry.classList.toggle('active', link.dataset.url === url);
+    }
+  });
+}
+
+function showLoading() {
+  contentArea.innerHTML = '<div class="content-loading">Loading…</div>';
+}
+
+function loadContent(url) {
+  showLoading();
+
+  fetch(url)
+    .then(function (res) {
+      if (!res.ok) throw new Error('Network response was not ok');
+      return res.text();
+    })
+    .then(function (html) {
+      var parser = new DOMParser();
+      var doc = parser.parseFromString(html, 'text/html');
+      var incoming = doc.getElementById('content-area');
+      if (incoming) {
+        contentArea.innerHTML = incoming.innerHTML;
+      } else {
+        // Fallback: show full page
+        window.location.href = url;
+      }
+      contentArea.scrollTop = 0;
+      setActiveLink(url);
+      history.pushState({ url: url }, doc.title || '', url);
+      document.title = doc.title || 'JY notes';
+    })
+    .catch(function () {
+      // On any fetch failure, do a regular navigation
+      window.location.href = url;
+    });
+}
+
+// Intercept nav clicks
+document.querySelector('.nav-rail').addEventListener('click', function (e) {
+  var link = e.target.closest('[data-url]');
+  if (!link) return;
+  var url = link.dataset.url;
+  if (!url) return;
+  e.preventDefault();
+  if (url === window.location.pathname) return; // already here
+  loadContent(url);
+});
+
+// Handle browser back/forward
+window.addEventListener('popstate', function (e) {
+  var url = (e.state && e.state.url) || window.location.pathname;
+  showLoading();
+
+  fetch(url)
+    .then(function (res) { return res.text(); })
+    .then(function (html) {
+      var parser = new DOMParser();
+      var doc = parser.parseFromString(html, 'text/html');
+      var incoming = doc.getElementById('content-area');
+      if (incoming) {
+        contentArea.innerHTML = incoming.innerHTML;
+      }
+      contentArea.scrollTop = 0;
+      setActiveLink(url);
+      document.title = doc.title || 'JY notes';
+    })
+    .catch(function () {
+      window.location.href = url;
+    });
+});
+
+// Mark the initial active item on page load
+setActiveLink(window.location.pathname);
+
+// Seed initial history state so popstate fires correctly on first back
+history.replaceState({ url: window.location.pathname }, document.title, window.location.pathname);


### PR DESCRIPTION
…/light/system theme, and SPA nav

- Update site title to "JY notes" in _config.yml
- Override Minima layouts with custom _layouts/default.html, home.html, post.html
- Add assets/css/style.scss: split-panel layout (25/75), CSS custom properties for light/dark/system themes, Instrument Serif for headings, Google Sans Code for body
- Add assets/js/app.js: theme toggle with localStorage persistence, SPA navigation that fetches post content and injects into right panel without full page reload, browser history (pushState/popstate) support

https://claude.ai/code/session_01AnqYgHicUzHGLou9298ksN